### PR TITLE
✨ feat: support function components in render logic

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,7 +51,8 @@ export default [
       react
     },
     rules: {
-      'react/react-in-jsx-scope': 'off'
+      'react/react-in-jsx-scope': 'off',
+      'react/jsx-uses-vars': 'error'
     }
   },
   prettier

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,0 +1,15 @@
+export default function App({ name }) {
+  return (
+    <div className="container">
+      <h1 className="title">Welcome to My App, {name}</h1>
+      <section className="intro">
+        <p>Hello, this is a simple custom renderer demo.</p>
+        <ul>
+          <li key="1">Supports JSX</li>
+          <li key="2">Handles nested elements</li>
+          <li key="3">Applies basic props like className</li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -1,19 +1,6 @@
 import '../setup/setupGlobals';
 import { render } from '../core/render';
-
-const element = (
-  <div className="container">
-    <h1 className="title">Welcome to My App</h1>
-    <section className="intro">
-      <p>Hello, this is a simple custom renderer demo.</p>
-      <ul>
-        <li>Supports JSX</li>
-        <li>Handles nested elements</li>
-        <li>Applies basic props like className</li>
-      </ul>
-    </section>
-  </div>
-);
+import App from './App';
 
 const root = document.getElementById('root');
-render(element, root);
+render(<App name="wanja" />, root);

--- a/src/core/render.js
+++ b/src/core/render.js
@@ -2,6 +2,12 @@ export function render(vnode, container) {
   //TODO diff알고리즘과 Virtual Dom 구현시 변경 예정
   container.innerHTML = '';
 
+  // 함수형 컴포넌트인 경우 실행하여 vnode를 반환받고 다시 렌더링
+  if (typeof vnode.type === 'function') {
+    const nextVNode = vnode.type(vnode.props);
+    return render(nextVNode, container);
+  }
+
   const dom = createDom(vnode);
   container.appendChild(dom);
 }
@@ -31,7 +37,6 @@ function createDom(vnode) {
       dom.setAttribute(prop, vnode.props[prop]);
     }
   }
-
   //children 배열로 표준화
   const children = Array.isArray(props.children)
     ? props.children


### PR DESCRIPTION
## 작업 완료 내역

### ✨ 기능 추가
- `render` 함수에서 `vnode.type`이 함수인 경우, 해당 함수형 컴포넌트를 실행하고 반환된 vnode를 다시 렌더링하는 분기 로직 추가

### 🍰 샘플 코드 작성
- `App.jsx`에 함수형 컴포넌트를 정의하고, 중첩된 JSX 구조를 포함시켜 테스트용 샘플로 작성
- `main.jsx`에서 `render(<App />)` 형식으로 함수형 컴포넌트가 잘 동작하는지 확인할 수 있도록 구성

### 💄 스타일 설정
- ESLint에서 JSX 내 컴포넌트 사용 시 `no-unused-vars` 경고가 발생하지 않도록 `react/jsx-uses-vars` 룰 추가
- CI에서 `<App />` 사용 시 발생하던 불필요한 lint 오류 해결

---

### 주요 고민 및 해결과정

#### ❗️문제 상황
- 함수형 컴포넌트를 지원하기 위해 `createElement` 내부에서 `type(props)`를 즉시 실행하도록 구현했음
- 이로 인해 반환된 결과는 더 이상 함수형 컴포넌트를 담은 vnode가 아니라, 바로 일반 vnode가 되었고,
  테스트나 디버깅에서 `vnode.type === MyComponent` 와 같은 비교가 불가능해짐
- 또한, 추후 가상 DOM diffing 구현 시에도 type이 함수인지 여부를 기반으로 비교해야 하는데,
  이 정보를 사전에 잃어버리게 됨

#### 🤔 구조적 고민
- React의 구조에서는 `createElement`는 vnode 객체만 생성하고, 함수형 컴포넌트의 실행은 실제 render(Fiber) 단계에서 처리됨
- 이 구조를 따라가면 다음과 같은 장점이 있음:
  - vnode에 함수형 컴포넌트가 그대로 type으로 유지되어 테스트와 디버깅이 쉬움
  - 추후 diff 알고리즘에서 type이 함수인지 확인 가능
  - 렌더링 시점을 통일시켜 side effect 및 상태 관리를 명확하게 분리 가능

#### ✅ 최종 결정 및 구현
- React의 구조를 따르기로 결정하고, `render` 함수에서 `vnode.type`이 함수인 경우에만 해당 함수형 컴포넌트를 실행하도록 변경함
- `createElement`는 type이 함수든 문자열이든 상관없이 실행하지 않고 그대로 vnode를 반환
- 이렇게 함으로써 테스트 신뢰도와 추후 기능 확장성을 모두 확보함

---

-  closes #5 