### PR TITLE
Refactor/create element and render

### DIFF
--- a/src/__tests__/creatElement.test.js
+++ b/src/__tests__/creatElement.test.js
@@ -12,18 +12,34 @@ describe('createElement 함수', () => {
   describe('기본 구조', () => {
     it('type과 props를 포함한 vnode를 생성해야 한다', () => {
       const vnode = createElement('div', { id: 'x' }, 'hi');
-      expectVNode(vnode, 'div', { id: 'x', children: 'hi' });
+      expectVNode(vnode, 'div', {
+        id: 'x',
+        children: {
+          type: 'TEXT_ELEMENT',
+          props: { nodeValue: 'hi', children: [] }
+        }
+      });
     });
 
     it('props 없이 호출할 경우 빈 props 객체로 처리되어야 한다', () => {
       const vnode = createElement('div', null, 'hi');
-      expectVNode(vnode, 'div', { children: 'hi' });
+      expectVNode(vnode, 'div', {
+        children: {
+          type: 'TEXT_ELEMENT',
+          props: { nodeValue: 'hi', children: [] }
+        }
+      });
       expect(Object.keys(vnode.props)).toEqual(['children']);
     });
 
     it('config가 undefined일 경우에도 정상 동작해야 한다', () => {
       const vnode = createElement('div', undefined, 'hi');
-      expectVNode(vnode, 'div', { children: 'hi' });
+      expectVNode(vnode, 'div', {
+        children: {
+          type: 'TEXT_ELEMENT',
+          props: { nodeValue: 'hi', children: [] }
+        }
+      });
       expect(Object.keys(vnode.props)).toEqual(['children']);
     });
 
@@ -37,29 +53,39 @@ describe('createElement 함수', () => {
   });
 
   describe('children 처리', () => {
-    it('children이 문자열 1개일 경우 props.children이 해당 문자열이어야 한다', () => {
-      const vnode = createElement('div', { id: 'x' }, 'hi');
-      expect(vnode.props.children).toBe('hi');
+    it('문자열 children은 TEXT_ELEMENT 타입의 VNode로 변환되어야 한다', () => {
+      const vnode = createElement('div', null, 'hi');
+      expect(vnode.props.children.type).toBe('TEXT_ELEMENT');
+      expect(vnode.props.children.props.nodeValue).toBe('hi');
     });
 
-    it('children이 여러 개일 경우 props.children이 배열이어야 한다', () => {
+    it('숫자 children도 TEXT_ELEMENT 타입으로 변환되어야 한다', () => {
+      const vnode = createElement('div', null, 123);
+      expect(vnode.props.children.type).toBe('TEXT_ELEMENT');
+      expect(vnode.props.children.props.nodeValue).toBe(123);
+    });
+
+    it('children이 여러 개일 경우 props.children은 배열로 유지되며 각 항목이 VNode 또는 값이어야 한다', () => {
       const vnode = createElement(
         'div',
         { id: 'x' },
         createElement('div', { id: 'y' }, 'hello'),
-        createElement('div', { id: 'z' }, 'nice to meet you')
+        createElement('div', { id: 'z' }, 'nice to meet you'),
+        null,
+        false
       );
+
       expect(Array.isArray(vnode.props.children)).toBe(true);
+      expect(vnode.props.children.length).toBe(4);
+      expect(vnode.props.children[0].type).toBe('div');
+      expect(vnode.props.children[1].type).toBe('div');
+      expect(vnode.props.children[2]).toBe(null);
+      expect(vnode.props.children[3]).toBe(false);
     });
 
-    it('children 없이 호출할 경우 props.children이 없어야 한다', () => {
-      const vnode = createElement('div', { id: 'x' });
-      expect(vnode.props.children).toBeUndefined();
-    });
-
-    it('falsy한 children(null, false 등)이 그대로 children으로 들어가는지 확인한다', () => {
-      const vnode = createElement('div', null, null);
-      expect(vnode.props.children).toBeNull();
+    it('null, undefined, boolean children도 props.children에 포함되지만 렌더링되지 않는다', () => {
+      const vnode = createElement('div', null, null, undefined, false, true);
+      expect(vnode.props.children).toEqual([null, undefined, false, true]);
     });
 
     it('children에 문자열과 vNode가 혼합되어도 잘 나와야 한다.', () => {
@@ -70,17 +96,22 @@ describe('createElement 함수', () => {
         createElement('span', null, 'nested')
       );
       expect(Array.isArray(vnode.props.children)).toBe(true);
-      expect(vnode.props.children[0]).toBe('text');
+      expect(vnode.props.children[0].type).toBe('TEXT_ELEMENT');
+      expect(vnode.props.children[0].props.nodeValue).toBe('text');
       expect(vnode.props.children[1].type).toBe('span');
-      expect(vnode.props.children[1].props.children).toBe('nested');
+      expect(vnode.props.children[1].props.children.type).toBe('TEXT_ELEMENT');
+      expect(vnode.props.children[1].props.children.props.nodeValue).toBe(
+        'nested'
+      );
     });
 
-    it('숫자 children을 그대로 props.children에 할당해야 한다', () => {
+    it('숫자 children도 TEXT_ELEMENT 타입으로 변환되어야 한다', () => {
       const vnode = createElement('div', null, 123);
-      expect(vnode.props.children).toBe(123);
+      expect(vnode.props.children.type).toBe('TEXT_ELEMENT');
+      expect(vnode.props.children.props.nodeValue).toBe(123);
     });
 
-    it('boolean children도 값 그대로 props.children에 포함되어야 한다', () => {
+    it('boolean children은 props.children에 포함되지만 렌더링 시 무시된다', () => {
       const vnode = createElement('div', null, false);
       expect(vnode.props.children).toBe(false);
     });
@@ -89,7 +120,8 @@ describe('createElement 함수', () => {
   describe('props 처리', () => {
     it('props로 넘긴 children보다 인자로 받은 children이 우선되어야 한다', () => {
       const vnode = createElement('div', { children: 'manual' }, 'auto');
-      expect(vnode.props.children).toBe('auto');
+      expect(vnode.props.children.type).toBe('TEXT_ELEMENT');
+      expect(vnode.props.children.props.nodeValue).toBe('auto');
     });
   });
 });

--- a/src/__tests__/creatElement.test.js
+++ b/src/__tests__/creatElement.test.js
@@ -105,12 +105,6 @@ describe('createElement 함수', () => {
       );
     });
 
-    it('숫자 children도 TEXT_ELEMENT 타입으로 변환되어야 한다', () => {
-      const vnode = createElement('div', null, 123);
-      expect(vnode.props.children.type).toBe('TEXT_ELEMENT');
-      expect(vnode.props.children.props.nodeValue).toBe(123);
-    });
-
     it('boolean children은 props.children에 포함되지만 렌더링 시 무시된다', () => {
       const vnode = createElement('div', null, false);
       expect(vnode.props.children).toBe(false);

--- a/src/core/createElement.js
+++ b/src/core/createElement.js
@@ -1,28 +1,48 @@
 /**
  * createElement(type, config, ...children)
  *
- * JSX가 변환된 결과를 받아 Virtual DOM 객체(VNode)를 생성하는 함수.
- * React의 createElement와 동일한 인터페이스를 따르며, 내부에서는
- * config를 기반으로 props 객체를 구성하고 children을 props.children에 포함시킨다.
+ * JSX를 Virtual DOM(VNode) 객체로 변환하는 함수입니다.
+ * 이 함수는 구조를 정의하는 데 집중하며, 각 노드의 렌더링 여부는
+ * 렌더 단계에서 판단됩니다.
  *
- * - type: 문자열 태그명(e.g., 'div') 또는 함수형 컴포넌트
- * - config: JSX 속성 객체. 일반적으로 props에 해당하며, null일 수 있음
- * - children: 0개 이상 전달될 수 있으며, 다음 규칙에 따라 처리됨
- *    - 0개: props.children을 설정하지 않음
- *    - 1개: 단일 값으로 props.children에 저장
- *    - 2개 이상: 배열로 props.children에 저장
+ * - type: 태그 문자열(e.g. 'div') 또는 함수형 컴포넌트
+ * - config: JSX에서 전달된 props 객체 (null일 수 있음)
+ * - children: 0개 이상의 자식 요소로 다음과 같이 처리됩니다:
+ *    - 문자열(string)과 숫자(number)는 TEXT_ELEMENT로 래핑됩니다
+ *    - 그 외의 값(null, undefined, boolean 등)은 판단하지 않고 그대로 포함됩니다
+ *    - 유효한 children이 1개면 단일 값으로, 2개 이상이면 배열로 props.children에 저장됩니다
+ *    - children이 0개인 경우 props.children은 정의되지 않습니다
  *
- * React의 철학(선언형 UI, 직관적 데이터 흐름)을 반영하여,
- * JSX 구조와 VNode 구조가 자연스럽게 매핑되도록 설계됨
+ * 이 함수는 React의 선언형 철학을 반영하여 구조만 정의하고,
+ * 렌더링 판단은 별도로 수행되도록 설계되었습니다.
  */
 export function createElement(type, config, ...children) {
   const props = { ...config };
 
-  if (children.length === 1) {
-    props.children = children[0];
-  } else if (children.length > 1) {
-    props.children = children;
+  const normalizedChildren = children
+    .flat()
+    .map((child) =>
+      typeof child === 'string' || typeof child === 'number'
+        ? createTextElement(child)
+        : child
+    );
+
+  if (normalizedChildren.length === 1) {
+    props.children = normalizedChildren[0];
+  } else if (normalizedChildren.length > 1) {
+    props.children = normalizedChildren;
+  } else {
   }
 
   return { type, props };
+}
+
+function createTextElement(text) {
+  return {
+    type: 'TEXT_ELEMENT',
+    props: {
+      nodeValue: text,
+      children: []
+    }
+  };
 }

--- a/src/core/createElement.js
+++ b/src/core/createElement.js
@@ -27,11 +27,11 @@ export function createElement(type, config, ...children) {
         : child
     );
 
+  // children이 없는 경우 props.children은 정의하지 않음
   if (normalizedChildren.length === 1) {
     props.children = normalizedChildren[0];
   } else if (normalizedChildren.length > 1) {
     props.children = normalizedChildren;
-  } else {
   }
 
   return { type, props };

--- a/src/core/render.js
+++ b/src/core/render.js
@@ -1,6 +1,27 @@
+/**
+ * render(vnode, container)
+ *
+ * Virtual DOM(VNode)을 실제 DOM으로 변환하여 container에 마운트하는 함수입니다.
+ * React의 렌더링 방식과 유사하게 동작하며, 구조는 그대로 따르고 의미 판단은 이 단계에서 수행합니다.
+ *
+ * - vnode: Virtual DOM 노드. 문자열 태그, 함수형 컴포넌트, TEXT_ELEMENT 등을 포함할 수 있습니다
+ * - container: 렌더링 결과를 삽입할 실제 DOM 노드
+ *
+ * 처리 방식:
+ * - null, undefined, boolean과 같은 의미 없는 vnode는 렌더링하지 않고 무시됩니다
+ * - 함수형 컴포넌트는 실행하여 실제 vnode로 변환한 뒤 재귀적으로 렌더링됩니다
+ * - 일반 태그나 텍스트 vnode는 createDom을 통해 실제 DOM 노드로 변환되어 container에 추가됩니다
+ *
+ * 이 함수는 구조 + 의미까지 해석하여 실제 화면에 그려주는 단계입니다.
+ */
 export function render(vnode, container) {
   //TODO diff알고리즘과 Virtual Dom 구현시 변경 예정
   container.innerHTML = '';
+
+  // 의미 없는 루트 vnode는 렌더링하지 않음
+  if (!isRenderable(vnode)) {
+    return;
+  }
 
   // 함수형 컴포넌트인 경우 실행하여 vnode를 반환받고 다시 렌더링
   if (typeof vnode.type === 'function') {
@@ -12,11 +33,19 @@ export function render(vnode, container) {
   container.appendChild(dom);
 }
 
+/**
+ * createDom(vnode)
+ *
+ * 주어진 Virtual DOM 노드(vnode)를 실제 DOM 노드로 변환하는 함수입니다.
+ * - TEXT_ELEMENT인 경우 텍스트 노드를 생성합니다.
+ * - 일반 태그인 경우 DOM 요소를 생성하고 props를 attribute로 설정합니다.
+ * - children은 배열로 정규화하여 재귀적으로 처리하며, isRenderable로 필터링합니다.
+ *
+ * 반환된 DOM 노드는 상위 요소에 append되어 화면에 렌더링됩니다.
+ */
 function createDom(vnode) {
-  // TODO createTextElement로 래핑
-  // 현재는 리팽이 되어있지 않아서 createDome내부에서 처리
-  if (typeof vnode === 'string') {
-    return document.createTextNode(vnode);
+  if (vnode.type === 'TEXT_ELEMENT') {
+    return document.createTextNode(vnode.props.nodeValue);
   }
 
   const { type, props } = vnode;
@@ -37,18 +66,28 @@ function createDom(vnode) {
       dom.setAttribute(prop, vnode.props[prop]);
     }
   }
+
   //children 배열로 표준화
   const children = Array.isArray(props.children)
     ? props.children
     : [props.children];
 
   //재귀적으로 자식 랜더링
-  children.forEach((child) => {
-    if (child != null) {
-      const childDom = createDom(child);
-      dom.appendChild(childDom);
-    }
+  children.filter(isRenderable).forEach((child) => {
+    const childDom = createDom(child);
+    dom.appendChild(childDom);
   });
 
   return dom;
+}
+
+/**
+ * isRenderable(child)
+ *
+ * 해당 child가 실제 DOM으로 렌더링 가능한 값인지 여부를 판단합니다.
+ * - null, undefined, boolean은 의미 없는 값으로 간주되어 false를 반환합니다.
+ * - 나머지 값들은 true를 반환하여 렌더링 대상이 됩니다.
+ */
+function isRenderable(child) {
+  return !(child === null || child === undefined || typeof child === 'boolean');
 }

--- a/src/core/render.js
+++ b/src/core/render.js
@@ -51,19 +51,12 @@ function createDom(vnode) {
   const { type, props } = vnode;
   const dom = document.createElement(type);
 
-  // key 설정
+  // prop 설정 (className, 기타 속성 처리)
   for (const key in props) {
-    if (key !== 'children') {
+    if (key === 'className') {
+      dom.className = props[key];
+    } else if (key !== 'children' && key !== 'key') {
       dom.setAttribute(key, props[key]);
-    }
-  }
-
-  //prop 설정
-  for (const prop in vnode.props) {
-    if (prop === 'className') {
-      dom.className = vnode.props[prop];
-    } else {
-      dom.setAttribute(prop, vnode.props[prop]);
     }
   }
 


### PR DESCRIPTION
## 작업 완료 내역

### ♻️ 리팩토링: TEXT_ELEMENT 처리 및 렌더 필터링 개선
- 문자열 및 숫자 children을 `TEXT_ELEMENT`로 래핑하기 위해 `createTextElement` 함수 도입
- 구조 정의는 `createElement`, 렌더 판단은 `render`에서 수행하도록 분리
- `isRenderable` 헬퍼로 `null`, `undefined`, `boolean` 값 렌더링 필터링
- 관련 테스트 코드를 구조 기반으로 재작성
- 주요 함수에 JSDoc 스타일 주석 추가

### ♻️ 리팩토링: DOM 속성 처리 정리
- `children`과 `key`는 DOM 속성 설정에서 제외
- `className`은 `setAttribute`가 아닌 속성 직접 할당
- 의미 없는 속성의 DOM 오염 방지

### 🙈 기타: 린트 오류 해결
- `vitest/no-identical-title` 오류 해결을 위해 중복 테스트 제목 수정
- `no-empty` 오류 해결을 위해 빈 블록 제거 및 주석 위치 조정

### ✅ 테스트 코드 업데이트: TEXT_ELEMENT 및 렌더링 규칙에 맞게 수정
- 문자열, 숫자 children은 TEXT_ELEMENT로 변환되어야 함을 테스트로 명시
- `null`, `undefined`, `boolean` children은 props.children에 포함되지만 렌더링되지 않음을 테스트
- 문자열과 VNode 혼합된 children도 배열로 구성되고 각 항목이 올바르게 변환되는지 확인


---

## 주요 고민 및 해결과정

### 1. children에 들어올 수 있는 값의 타입 혼란

초기 `createElement` 구현에서는 `children`으로 전달되는 값이 문자열, 숫자, `null`, `undefined`, boolean, 혹은 VNode 등 다양해 어떤 값은 TEXT_ELEMENT로 변환해야 하고, 어떤 값은 무시하거나 그대로 남겨야 하는지 기준이 불명확했습니다.  
특히 `false`나 `null`을 렌더링하지 않으면서도 `props.children`에는 포함할지 여부가 헷갈렸습니다.

**➡️ 해결:**  
- React처럼 구조 정의(`createElement`)와 렌더 판단(`render`)을 **책임 분리**함.  
- `createElement`는 가능한 한 원시값을 가공하지 않고 그대로 `props.children`에 넣음.  
- 렌더링 여부는 `render` 내부의 `isRenderable` 헬퍼 함수에서 판단하도록 위임.

---

### 2. 불필요한 값이 DOM 속성으로 들어가는 문제

기존 `createDom`에서는 `children`, `key` 등의 내부 속성이 DOM에 `setAttribute`로 그대로 적용되는 문제가 있었습니다.  
이로 인해 불필요한 속성이 DOM에 삽입되고, 이는 디버깅을 어렵게 만들고 구조적으로도 부적절했습니다.

**➡️ 해결:**  
- `createDom`에서 `children`, `key`는 명시적으로 제외.  
- `className`은 `setAttribute`가 아닌 `dom.className = ...` 방식으로 명확하게 처리.  
- 그 외 속성만 순회하며 `setAttribute`를 적용하는 방식으로 리팩토링.

---

### 3. children이 없는 경우 undefined vs 빈 배열

초기에는 `createElement`에서 `children`이 없으면 `props.children`을 `undefined`로 유지했습니다.  
그러나 `render`에서 `children`을 순회할 때마다 존재 여부를 조건문으로 체크해야 하며, 테스트 코드에서도 일관된 처리가 어려워졌습니다.

**➡️ 해결:**  
- `createElement`는 `children`이 없는 경우 아예 `props.children`을 생략하여 구조만 정의.  
- `render`에서 `props.children`을 항상 배열로 표준화 (`Array.isArray` 확인 후 `[]`로 감싸기) 하여 이후 처리 흐름을 단순화.  
- 이는 React 내부 처리 방식과도 유사하며, 구조 정의와 렌더링 책임을 분리하는 데 도움이 됨.

---

### 4. 테스트 코드와 실제 구현의 불일치

기존 테스트는 boolean, null, undefined 값을 무조건 필터링하거나 TEXT_ELEMENT로 만들기를 기대하고 있었습니다.  
하지만 React는 이들을 `props.children`에는 그대로 포함시키되, **렌더링 시 무시**하는 방식을 취합니다.

**➡️ 해결:**  
- 테스트 케이스를 전면 수정하여 React 철학에 맞게 재작성.  
- 구조 확인 테스트와 렌더 확인 테스트를 구분해 역할과 책임을 명확히 분리.

---

### 5. 린트 오류로 인한 워크플로우 중단

중복된 테스트 제목과 빈 블록으로 인해 CI에서 린트 오류가 발생했고, 커밋이 막히는 일이 있었습니다.

**➡️ 해결:**  
- `vitest/no-identical-title` 규칙에 맞게 테스트 제목을 모두 고유하게 변경.  
- 빈 블록은 제거하고 주석은 외부로 이동하여 의도 전달.
---

  - closes #20 