### PR TITLE
🐛 fix: nested function component rendering with tests

### DIFF
--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -42,4 +42,32 @@ describe('render', () => {
     expect(container.innerHTML).not.toContain('Old');
     expect(container.textContent).toBe('New');
   });
+
+  it('함수형 컴포넌트를 렌더링해야 합니다.', () => {
+    const Sample = () => createElement('p', null, 'Sample Text');
+    const vnode = createElement(Sample, null);
+    render(vnode, container);
+
+    const p = container.querySelector('p');
+    expect(p).toBeTruthy();
+    expect(p.textContent).toBe('Sample Text');
+  });
+
+  it('중첩된 함수형 컴포넌트를 렌더링해야 합니다.', () => {
+    const Inner = () => createElement('span', null, 'Inner');
+    const Middle = () => createElement('div', null, createElement(Inner));
+    const Outer = () => createElement('section', null, createElement(Middle));
+
+    const vnode = createElement(Outer, null);
+    render(vnode, container);
+
+    const section = container.querySelector('section');
+    const div = container.querySelector('div');
+    const span = container.querySelector('span');
+
+    expect(section).toBeTruthy();
+    expect(div).toBeTruthy();
+    expect(span).toBeTruthy();
+    expect(span.textContent).toBe('Inner');
+  });
 });

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,3 +1,5 @@
+import Sample from './Sample';
+
 export default function App({ name }) {
   return (
     <div className="container">
@@ -10,6 +12,7 @@ export default function App({ name }) {
           <li key="3">Applies basic props like className</li>
         </ul>
       </section>
+      <Sample />
     </div>
   );
 }

--- a/src/app/Sample.jsx
+++ b/src/app/Sample.jsx
@@ -1,0 +1,16 @@
+export default function Sample() {
+  return (
+    <div>
+      Sample
+      <ChildSample />
+    </div>
+  );
+}
+
+function ChildSample() {
+  return (
+    <div>
+      ChildSample <div>oh~</div>
+    </div>
+  );
+}

--- a/src/core/render.js
+++ b/src/core/render.js
@@ -44,6 +44,13 @@ export function render(vnode, container) {
  * 반환된 DOM 노드는 상위 요소에 append되어 화면에 렌더링됩니다.
  */
 function createDom(vnode) {
+  // 함수형 컴포넌트면 먼저 실행해서 vnode를 얻고 다시 처리
+  if (typeof vnode.type === 'function') {
+    const nextVNode = vnode.type(vnode.props);
+    return createDom(nextVNode);
+  }
+
+  // TEXT_ELMENT 처리
   if (vnode.type === 'TEXT_ELEMENT') {
     return document.createTextNode(vnode.props.nodeValue);
   }

--- a/src/core/render.js
+++ b/src/core/render.js
@@ -25,8 +25,7 @@ export function render(vnode, container) {
 
   // 함수형 컴포넌트인 경우 실행하여 vnode를 반환받고 다시 렌더링
   if (typeof vnode.type === 'function') {
-    const nextVNode = vnode.type(vnode.props);
-    return render(nextVNode, container);
+    return render(evaluateFunctionComponent(vnode), container);
   }
 
   const dom = createDom(vnode);
@@ -46,8 +45,7 @@ export function render(vnode, container) {
 function createDom(vnode) {
   // 함수형 컴포넌트면 먼저 실행해서 vnode를 얻고 다시 처리
   if (typeof vnode.type === 'function') {
-    const nextVNode = vnode.type(vnode.props);
-    return createDom(nextVNode);
+    return createDom(evaluateFunctionComponent(vnode));
   }
 
   // TEXT_ELMENT 처리
@@ -90,4 +88,13 @@ function createDom(vnode) {
  */
 function isRenderable(child) {
   return !(child === null || child === undefined || typeof child === 'boolean');
+}
+
+/**
+ * evaluateFunctionComponent(vnode)
+ *
+ * 함수형 컴포넌트 vnode를 실제 vnode로 변환합니다.
+ */
+function evaluateFunctionComponent(vnode) {
+  return vnode.type(vnode.props);
 }


### PR DESCRIPTION


### 주요 변경 사항

### 🐛fix
- 중첩된 함수형 컴포넌트가 `createElement(type)` 호출 시 `type`에 함수가 들어가 `InvalidCharacterError`가 발생하던 문제를 수정했습니다.
- `render`와 `createDom`에서 모두 함수형 컴포넌트를 분기 처리하도록 하여 중첩 구조에서도 정상적으로 렌더링되도록 개선했습니다.
- `render.test.js`에 단일 및 중첩 함수형 컴포넌트 렌더링을 검증하는 테스트 케이스를 추가했습니다.

---

### 주요 고민 및 해결 과정

#### 중첩 컴포넌트 랜더링이 안되던 버그 해결

- **문제 배경**  
  함수형 컴포넌트가 중첩될 경우, 자식 컴포넌트가 아직 실행되지 않은 함수인 상태로 `createDom`에 전달되어  
  `document.createElement(function...)` 호출 시 브라우저가 유효하지 않은 태그 이름으로 판단해 에러(`InvalidCharacterError`)가 발생했습니다.

- **초기 접근 방식**  
  처음에는 루트에서만 함수형 컴포넌트를 처리하면 된다고 판단하여 `render()`에서만 분기 처리했습니다.  
  그러나 컴포넌트가 중첩될 경우 자식 vnode 또한 함수형일 수 있기 때문에  
  `createDom()` 내에서도 동일한 분기 처리가 필요함을 확인했습니다.

- **구조적 고민**  
  모든 vnode를 `render` 단계에서 flatten하여 처리할 수도 있었지만,  
  그렇게 하면 `render`가 지나치게 많은 책임을 지게 되어 역할 분리를 위해 `createDom`에서도 처리하도록 했습니다.

- **최종 결정**  
  React도 실제로 루트 컴포넌트만 처리하는 것이 아니라 Fiber 단계에서 각 노드를 순회하며 타입에 따라 처리하므로,  
  동일한 철학에 기반해 `createDom`과 `render` 양쪽 모두에서 함수형 컴포넌트를 분기 처리하는 구조를 택했습니다.

---

### 기타 작업

- 🙈 샘플 렌더링 확인을 위해 `App`, `Sample` 등의 테스트용 컴포넌트를 작성했습니다.
- ♻️ `evaluateFunctionComponent` 유틸 함수를 분리하여 중복된 로직을 제거하고 명확한 역할로 분리했습니다.  
  이 함수는 컴포넌트를 실행해 실제 vnode를 반환하는 역할만 담당하며, create/render 로직과 분리되었습니다.


- closes #24 