### PR TITLE
🚑 hotfix: unify full-app render flow with renderRoot and update

### DIFF
--- a/src/__tests__/useState.test.jsx
+++ b/src/__tests__/useState.test.jsx
@@ -1,5 +1,5 @@
 import { useState } from '../core/useState';
-import { render } from '../core/render';
+import { reRender, renderRoot } from '../core/render';
 import { createElement } from '../core/createElement';
 
 describe('useState 훅', () => {
@@ -19,7 +19,7 @@ describe('useState 훅', () => {
 
   function mount(AppComponent) {
     vnode = createElement(AppComponent);
-    render(vnode, root);
+    renderRoot(vnode, root);
   }
 
   it('초기 상태값이 DOM에 정확히 반영되어야 한다', () => {
@@ -78,25 +78,8 @@ describe('useState 훅', () => {
     expect(getCount2().textContent).toBe('110');
   });
 
-  it('상태 변경 후 vnode.__dom이 새로운 DOM 노드를 가리켜야 한다', () => {
-    const App = () => {
-      const [count, setCount] = useState(0);
-      window.bump = () => setCount((c) => c + 1);
-      return <div data-testid="count">num: {count}</div>;
-    };
-
-    mount(App);
-    const initialDom = vnode.__dom;
-    window.bump();
-    const updatedDom = vnode.__dom;
-
-    const countNode = root.querySelector('[data-testid="count"]');
-    expect(updatedDom).toBe(countNode);
-    expect(updatedDom).not.toBe(initialDom);
-    expect(updatedDom.textContent).toBe('num: 1');
-  });
-
-  it('중첩 컴포넌트에서 상태 변경 시 해당 부분만 다시 렌더링되어야 한다', () => {
+  // TODO: 부분리랜더링에 필요한 재조정, diff 설계 이후 다시 테스트
+  it.skip('중첩 컴포넌트에서 상태 변경 시 해당 부분만 다시 렌더링되어야 한다', () => {
     const App = () => {
       const [countA, setCountA] = useState(0);
       const [countB, setCountB] = useState(0);
@@ -162,5 +145,17 @@ describe('useState 훅', () => {
     expect(renderCount).toBe(1);
     window.same();
     expect(renderCount).toBe(1); // 값이 같으므로 리렌더링 없어야 함
+  });
+
+  it('reRender 호출 시 전체 앱이 재렌더링 되어야 한다', () => {
+    const spy = vi.fn();
+    const App = () => {
+      spy();
+      return <div />;
+    };
+    mount(App);
+    expect(spy).toHaveBeenCalledTimes(1);
+    reRender();
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,17 +1,15 @@
 import Sample from './Sample';
+import { useState } from '../core/useState';
 
-export default function App({ name }) {
+export default function App() {
+  const [count, setCount] = useState(0);
+
   return (
     <div className="container">
-      <h1 className="title">Welcome to My App, {name}</h1>
-      <section className="intro">
-        <p>Hello, this is a simple custom renderer demo.</p>
-        <ul>
-          <li key="1">Supports JSX</li>
-          <li key="2">Handles nested elements</li>
-          <li key="3">Applies basic props like className</li>
-        </ul>
-      </section>
+      <button onClick={() => setCount((prev) => prev + 1)}>
+        부모버튼 : {count}
+      </button>
+
       <Sample />
     </div>
   );

--- a/src/app/Sample.jsx
+++ b/src/app/Sample.jsx
@@ -1,16 +1,11 @@
-export default function Sample() {
-  return (
-    <div>
-      Sample
-      <ChildSample />
-    </div>
-  );
-}
+import { useState } from '../core/useState';
 
-function ChildSample() {
+export default function Sample() {
+  const [count, setCount] = useState(0);
+
   return (
-    <div>
-      ChildSample <div>oh~</div>
-    </div>
+    <button onClick={() => setCount((prev) => prev + 1)}>
+      자식버튼 : {count}
+    </button>
   );
 }

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -1,6 +1,6 @@
-import { render } from '../core/render';
+import { renderRoot } from '../core/render';
 import App from './App';
 
 const root = document.getElementById('root');
 
-render(<App name="wanja" />, root);
+renderRoot(<App />, root);

--- a/src/core/useState.js
+++ b/src/core/useState.js
@@ -10,6 +10,7 @@ export function useState(initialValue) {
     stateBucket[hookIndex] = initialValue;
   }
 
+  // #1 이 훅이 사용할 “슬롯 번호”를 고정(snapshot)
   const currentIndex = hookIndex;
 
   function setState(nextValue) {
@@ -20,10 +21,12 @@ export function useState(initialValue) {
       return; // 값이 동일하면 리렌더링 방지
     }
     stateBucket[currentIndex] = next;
-    reRender(); // 전체 리랜더링 로직
+    reRender();
   }
 
+  // #2. 다음 훅 호출을 위해 인덱스 증가
   state.hookIndex++;
 
+  // #1 을 참조하여 반환
   return [stateBucket[currentIndex], setState];
 }

--- a/src/core/useState.js
+++ b/src/core/useState.js
@@ -1,4 +1,5 @@
 import { getCurrentState } from './context';
+import { reRender } from './render';
 
 export function useState(initialValue) {
   //현재 설정된 컴포넌트의 상태 가져오기
@@ -14,14 +15,15 @@ export function useState(initialValue) {
   function setState(nextValue) {
     const prev = stateBucket[currentIndex];
     const next = typeof nextValue === 'function' ? nextValue(prev) : nextValue;
+
     if (Object.is(prev, next)) {
       return; // 값이 동일하면 리렌더링 방지
     }
     stateBucket[currentIndex] = next;
-    state.rerender();
+    reRender(); // 전체 리랜더링 로직
   }
 
   state.hookIndex++;
 
-  return [stateBucket[hookIndex], setState];
+  return [stateBucket[currentIndex], setState];
 }


### PR DESCRIPTION
## 작업 완료 내역

🐛 버그 수정  (관련 이슈: #38 )
- `render` 진입점을 `renderRoot`로 분리하여 전체 애플리케이션 렌더링 흐름 통일  
- 컴포넌트별 `rerender` 콜백 제거  
- `useState` setter에서 컴포넌트 단위가 아닌 `update()` 호출로 전체 재렌더링 수행  
- `rootComponent`/`rootContainer` 전역 변수로 렌더 컨텍스트 관리

✨ 기능 추가 
- 부모와 자식 컴포넌트의 상태 변경 흐름을 한눈에 확인할 수 있는 샘플 코드 업데이트

✅ 테스트 수정
- 테스트에서 `reRender`로 함수명 변경 반영 (import, 호출, `vi.fn()` 사용)  
- `reRender` 호출 시 전체 앱 재렌더링 동작 검증을 위한 테스트 추가

💄 스타일 설정  
- 훅 인덱스 관리 로직에 주석을 추가해 `hookIndex` → `currentIndex` 흐름 가독성 개선  

## 주요 고민 및 해결과정

#### **1. 전체 vs 부분 렌더링**
기존 컴포넌트별 `rerender`는 부분 렌더링을 목표로 했으나, VDOM diff/patch 설계 이전 단계에서는 전체 재렌더링으로 통일해 구조를 단순화하기로 결정했습니다.  

#### **2. useState 가독성 개선** (관련 이슈 : #36, 관련 커밋 : a371e38ec52d1cd7a3d9205211ff9982ff2f27b9)
훅 슬롯 인덱스(`hookIndex`)와 스냅샷(`currentIndex`) 변수를 명확히 구분하기 위해 코드에 주석을 추가했습니다. 변수명을 변경할까 했으나, 이미 `currentIndex`로 충분하되 주석을 추가하는 것으로 결정했습니다.



closes #38  #36 