### PR TITLE
🐛 fix: allow state reuse for function components without key

### DIFF
--- a/src/__tests__/componentState.test.js
+++ b/src/__tests__/componentState.test.js
@@ -1,0 +1,32 @@
+import { getComponentState, setComponentState } from '../core/componentState';
+
+describe('componentState', () => {
+  test('있고, 동일한 함수로 동일한 상태를 가져올 수 있어야 한다', () => {
+    function MyComponent() {}
+    const state = { count: 1 };
+
+    setComponentState(MyComponent, state);
+    const retrieved = getComponentState(MyComponent);
+
+    expect(retrieved).toBe(state);
+  });
+
+  test('원시값 키는 내부적으로 객체로 래핑되어 같은 키로 동일한 상태를 반환해야 한다', () => {
+    const key = 'myKey';
+    const state = { message: 'hello' };
+
+    setComponentState(key, state);
+    const retrieved = getComponentState(key);
+
+    expect(retrieved).toBe(state);
+  });
+
+  test('같은 instanceKey를 여러 번 사용해도 항상 같은 상태 객체를 반환해야 한다', () => {
+    const key = 42;
+    const state = { value: 42 };
+
+    setComponentState(key, state);
+    expect(getComponentState(key)).toBe(state);
+    expect(getComponentState(key)).toBe(state);
+  });
+});

--- a/src/core/componentState.js
+++ b/src/core/componentState.js
@@ -23,7 +23,10 @@ const finalizationRegistry = new FinalizationRegistry((primitiveKey) => {
  *   WeakMap의 키로 사용할 수 있는 객체 참조
  */
 function toWeakKey(instanceKey) {
-  if (typeof instanceKey === 'object' && instanceKey !== null) {
+  if (
+    (typeof instanceKey === 'object' || typeof instanceKey === 'function') &&
+    instanceKey !== null
+  ) {
     return instanceKey;
   }
   // 원시 키 처리 경로


### PR DESCRIPTION
## 주요 변경사항

- `toWeakKey` 함수에서 `typeof === 'function'`인 경우  
  → 기존처럼 래핑 객체를 만들지 않고 함수 참조를 그대로 반환하도록 수정
- `key`가 없는 함수형 컴포넌트라도 참조가 동일하면  
  → 상태를 일관되게 재사용할 수 있도록 개선
- 기존에 상태를 찾지 못해 `renderedVNode`가 생성되지 않고 자식 DOM이 제거되는 문제를 방지
- 함수형 컴포넌트와 원시 키 각각에 대해 상태 매핑이 일관적으로 작동하는지 검증하는 `테스트 코드` 추가

---

## 주요 문제와 해결

### 🤔 문제
함수형 컴포넌트에서 `key`를 명시하지 않으면  
`toWeakKey`에서 함수 타입을 인식하지 못하고  
dummy 객체로 래핑하거나 상태를 찾지 못해 컴포넌트가 호출되지 않음  
→ 그 결과 `children`이 빈 배열로 평가되어 기존 자식 DOM이 `removeChild()`로 제거됨  
→ **TodoApp이 간헐적으로 사라지는 현상 발생**

### ✅ 해결
- 함수 참조(`typeof === 'function'`)를 WeakMap의 key로 사용할 수 있으므로  
  래핑 없이 그대로 사용하도록 `toWeakKey` 로직 수정
- 동일한 함수형 컴포넌트 참조가 유지되면 key 없이도 상태 일관성 유지 가능
- 테스트 코드 추가를 통해 이 문제가 재발하지 않도록 검증

- closes #45 